### PR TITLE
Replace pytz with zoneinfo for timezone handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1037,17 +1037,6 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "pytz"
-version = "2024.2"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
-    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
-]
-
-[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
@@ -1403,4 +1392,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "78835de2efa3321fa933fc8f4d520d2db8cc75b6920f66b47e8915736724dcdc"
+content-hash = "2984ea9eb6e69d236438958ef7262113446acdc66edb4a2692e7bfb299c12f31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ package-mode = false
 python = "^3.13"
 poetry = "1.8.4"
 playwright = "1.48.0"
-pytz = "2024.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.7.0"

--- a/screenshot_mailinator_email.py
+++ b/screenshot_mailinator_email.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from sys import argv
+from zoneinfo import ZoneInfo
 
 from playwright.sync_api import sync_playwright
-from pytz import UTC
 
 
 def screenshot_mailinator_email() -> None:
@@ -18,7 +18,8 @@ def screenshot_mailinator_email() -> None:
         print("Loading email pane")
         page.evaluate("document.getElementById('email_pane').setAttribute('style', 'height: 500%; width: 100%;');")
         print("Enlarging email pane")
-        file_name = f"{datetime.now(tz=UTC).strftime('%Y-%m-%d_%H-%M-%S')}_email.png"
+        datetime_string = datetime.now(tz=ZoneInfo("Europe/London")).strftime("%Y-%m-%d_%H-%M-%S")
+        file_name = f"{datetime_string}_email.png"
         page.locator("#email_pane").screenshot(path=file_name)
         print(f"Saved screenshot to {file_name}")
         browser.close()


### PR DESCRIPTION
# Pull Request

## Description

This change removes the `pytz` dependency and replaces it with the built-in `zoneinfo` module for handling time zones. The `screenshot_mailinator_email.py` script now uses `ZoneInfo("Europe/London")` instead of `UTC` for timestamp generation. Additionally, the datetime string formatting has been separated into its own variable for improved readability.

The `pyproject.toml` file has been updated to remove the `pytz` dependency from the project requirements.

These changes modernise the time zone handling in the project and reduce external dependencies.