### PR TITLE
Add .coverage, *.png to clean command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -25,11 +25,13 @@ clean:
       -name '.mypy_cache' -o \
       -name '.pytest_cache' -o \
       -name '.ruff_cache' -o \
+      -name '.coverage' -o \
       -name '*.pyc' -o \
       -name '*.pyd' -o \
       -name '*.pyo' -o \
       -name 'coverage.xml' -o \
       -name 'db.sqlite3' \
+      -name '*.png' -o \
     \) -print | xargs rm -rfv
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the `clean` task in the Justfile by adding two new file patterns to be removed during cleanup:

1. Added `.coverage` to the list of directories to be deleted.
2. Included `*.png` files in the cleanup process.

These additions will help maintain a cleaner project directory by removing coverage data files and any PNG images that may have been generated during development or testing.