### PR TITLE
Add pre-commit cleanup script

### DIFF
--- a/githooks/pre-commit-scripts/cleanup.sh
+++ b/githooks/pre-commit-scripts/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+just clean


### PR DESCRIPTION
# Pull Request

## Description

This change adds a new pre-commit hook script named `cleanup.sh` in the `githooks/pre-commit-scripts/` directory. The script is designed to run the `just clean` command as part of the pre-commit process. This ensures that the project is cleaned up automatically before each commit, maintaining a consistent and tidy codebase.

The script uses `set -e` to exit immediately if any command fails, and `set +x` to disable command tracing for cleaner output. This addition will help streamline the development workflow and enforce cleanliness standards across the project.