### PR TITLE
Add GitHub Actions workflow for PR labelling

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,0 +1,31 @@
+# labels auto assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["README.md", "docs/**"]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/poetry.lock", "package-lock.json"]
+      - head-branch: ["^dependabot"]
+python:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["*.py", "**/*.py"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [".github/workflows/*", ".github/workflows/**/*"]
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,34 @@
+name: "Pull Request Checks"
+
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        edited,
+        unlocked,
+        labeled,
+        synchronize,
+        reopened,
+        ready_for_review,
+      ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeller:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Pull Request

## Description

This change introduces automated labelling for pull requests. It adds two new files:

1. `.github/other-configurations/labeller.yml`: Defines rules for automatically assigning labels to pull requests based on file changes and branch names. Labels include documentation, dependencies, python, just, shell, github_actions, and git_hooks.

2. `.github/workflows/pull-request-checks.yml`: Implements a GitHub Actions workflow that runs on pull request events. This workflow:
   - Uses the `actions/labeler` action to apply labels based on the rules defined in `labeller.yml`.
   - Adds size labels to pull requests using the `pascalgn/size-label-action`.

These additions will help streamline the pull request process by automatically categorising changes and providing quick visual indicators of the scope and type of modifications.