### PR TITLE
Fix Just Clean Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,7 @@ clean:
       -name '*.pyo' -o \
       -name 'coverage.xml' -o \
       -name 'db.sqlite3' \
-      -name '*.png' -o \
+      -name '*.png' \
     \) -print | xargs rm -rfv
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `clean` task in the Justfile to remove the `-o` (or) operator after the `*.png` pattern. This adjustment will ensure that PNG files are included in the cleanup process without being treated as an alternative condition for file removal.

The modification streamlines the file cleanup process by including PNG files alongside other temporary and generated files that are targeted for removal.