### PR TITLE
Enable file nesting in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,10 @@
     "**/__pycache__": true,
     "**/.ruff_cache": true,
     "**/.pytest_cache": true
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pyproject.toml": "__init__.py, poetry.lock, coverage.xml, .coverage, .gitignore"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "screenshot-mailinator-email"
+name = "screenshot_mailinator_email"
 package-mode = false
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the Visual Studio Code workspace settings and updates the project configuration:

1. In `.vscode/settings.json`:
   - Enabled file nesting in the explorer
   - Set file nesting to be collapsed by default
   - Added file nesting patterns for `pyproject.toml` to group related files

2. In `pyproject.toml`:
   - Modified the project name from "screenshot-mailinator-email" to "screenshot_mailinator_email"

These changes improve the organisation of project files in VS Code and update the project's naming convention.