### PR TITLE
Reorder Ruff fix commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -41,8 +41,8 @@ clean:
 
 # Fix all Ruff issues
 ruff-fix:
-    just ruff-lint-fix
     just ruff-format-fix
+    just ruff-lint-fix
 
 # Check for Ruff issues
 ruff-lint:


### PR DESCRIPTION
# Pull Request

## Description

Reorders the execution of Ruff commands in the Justfile to run formatting before linting. This ensures that any formatting changes are applied before lint checks are performed, which can help prevent unnecessary lint errors caused by formatting issues.