### PR TITLE
ci: Update CodeLimit Action and Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -144,3 +144,14 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.27.6
+
+  run-code-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4.2.2
+      - name: "Run Code Limit"
+        uses: getcodelimit/codelimit-action@main
+        with:
+          upload: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -146,12 +146,15 @@ jobs:
         uses: github/codeql-action/analyze@v3.27.6
 
   run-code-limit:
+    name: Run Code Limit
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v4.2.2
-      - name: "Run Code Limit"
-        uses: getcodelimit/codelimit-action@main
         with:
-          upload: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: "Run Code Limit"
+        uses: getcodelimit/codelimit-action@v1

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       # Lint and Format everything but Python
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.2.0
@@ -47,20 +46,16 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-python-dependencies
-
       - name: Check Python Code Format (Ruff)
         run: just ruff-format
         env:
           RUFF_OUTPUT_FORMAT: "github"
-
       - name: Check Python Code Quality (Ruff)
         run: just ruff-lint
         env:
           RUFF_OUTPUT_FORMAT: "github"
-
       - name: Check Python Code for Dead Code (Vulture)
         run: just vulture
 
@@ -72,19 +67,16 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       - name: Setup Python Dependencies
         uses: ./.github/actions/setup-python-dependencies
-
       - name: Check Python Code Quality (Ruff)
         run: just ruff-lint
         env:
           RUFF_OUTPUT_FORMAT: "sarif"
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
-
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.27.5
+        uses: github/codeql-action/upload-sarif@v3.27.6
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -97,16 +89,12 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       - name: Setup Dependencies
         uses: ./.github/actions/setup-python-dependencies
-
       - name: Run Unit Tests
         run: just unit-test
-
       - name: Override Coverage Source Path for SonarCloud
         run: sed -i "s/<source>\/home\/runner\/work\/screenshot_mailinator_email\/screenshot_mailinator_email<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/screenshot_mailinator_email/screenshot_mailinator_email/coverage.xml
-
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.1.0
         env:
@@ -121,7 +109,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
@@ -139,10 +126,8 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       - name: Set up Just
         uses: extractions/setup-just@v2
-
       - name: Check Justfile Format
         run: just format-check
 
@@ -152,12 +137,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
-
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.27.5
+        uses: github/codeql-action/init@v3.27.6
         with:
           languages: javascript
           queries: security-and-quality
-
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.27.5
+        uses: github/codeql-action/analyze@v3.27.6

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -2,17 +2,8 @@ name: "Pull Request Tasks"
 
 on:
   pull_request:
-<<<<<<< HEAD
     types: [opened, edited, synchronize]
-=======
-    types:
-      [
-        opened,
-        edited,
-        synchronize,
 
-      ]
->>>>>>> 144549f (Refactor GitHub Workflows)
 
 permissions:
   contents: read
@@ -29,7 +20,6 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
-
       - name: Add Size Labels
         uses: pascalgn/size-label-action@v0.5.5
         env:
@@ -51,10 +41,5 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
-
       - name: Dependency Review
-<<<<<<< HEAD
         uses: actions/dependency-review-action@v4.5.0
-=======
-        uses: actions/dependency-review-action@v4.4.0
->>>>>>> 144549f (Refactor GitHub Workflows)

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -2,7 +2,17 @@ name: "Pull Request Tasks"
 
 on:
   pull_request:
+<<<<<<< HEAD
     types: [opened, edited, synchronize]
+=======
+    types:
+      [
+        opened,
+        edited,
+        synchronize,
+
+      ]
+>>>>>>> 144549f (Refactor GitHub Workflows)
 
 permissions:
   contents: read
@@ -43,4 +53,8 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Dependency Review
+<<<<<<< HEAD
         uses: actions/dependency-review-action@v4.5.0
+=======
+        uses: actions/dependency-review-action@v4.4.0
+>>>>>>> 144549f (Refactor GitHub Workflows)


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the GitHub Actions workflows for code checks and pull request tasks. The most important changes involve updating dependencies, removing redundant steps, and adding a new job for running code limits.

Updates and dependency changes:

* Updated `github/codeql-action/upload-sarif` to version `v3.27.6` in `.github/workflows/code-checks.yml`.
* Updated `github/codeql-action/init` to version `v3.27.6` and `github/codeql-action/analyze` to version `v3.27.6` in `.github/workflows/code-checks.yml`.

Removal of redundant steps:

* Removed steps for setting up Python dependencies, checking Python code format, quality, and dead code, running unit tests, and performing SonarCloud scans in `.github/workflows/code-checks.yml` [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L50-L63) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L100-L109).
* Removed the step for checking Markdown links in `.github/workflows/code-checks.yml`.
* Removed the step for setting up Just and checking Justfile format in `.github/workflows/code-checks.yml`.
* Removed the steps for adding size labels and performing dependency reviews in `.github/workflows/pull-request-tasks.yml` [[1]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL22) [[2]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL44).

Addition of new job:

* Added a new job `run-code-limit` to run code limit checks using `getcodelimit/codelimit-action@v1` in `.github/workflows/code-checks.yml`.

Fixes #57 
