### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
@@ -20,7 +23,10 @@ updates:
     commit-message:
       prefix: "deps(python)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the schedule for Dependabot in the `.github/dependabot.yml` file to ensure more frequent updates and better alignment with the team's work hours.

Changes to Dependabot schedule:

* `updates` section for `github-actions`: Changed the update interval from daily to weekly, and added specifications for the day, time, and timezone.
* `updates` section for `python`: Changed the update interval from monthly to weekly, and added specifications for the day, time, and timezone.

Fixes #63