### PR TITLE
chore: Ungroup Major Application Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,6 @@ updates:
       python:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change specifies that Dependabot should update Python dependencies for both patch and minor versions.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R38-R40): Added `update-types` to include "patch" and "minor" updates for Python dependencies.

Fixes #69 