### PR TITLE
ci: Add Zizmor Checking

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -158,3 +158,28 @@ jobs:
           fetch-depth: 0
       - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@v1
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.0.1
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.28.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a new job in the GitHub Actions workflow to check GitHub Actions with `zizmor`. The most important changes include adding a new job `run-zizmor` to `.github/workflows/code-checks.yml`.

New GitHub Actions job:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R161-R185): Added a new job `run-zizmor` to check GitHub Actions with `zizmor`, including steps for checking out the repository, installing the latest version of `uv`, running `zizmor`, and uploading the SARIF file.

Fixes #75 
