### PR TITLE
Update license to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Jack Plowman
+Copyright (c) 2025 Jack Plowman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `LICENSE` file. The change updates the copyright year.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year from 2024 to 2025.

Fixes #86 