### PR TITLE
Remove Custom Line Length Rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,9 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-line-length = 120
 target-version = "py313"
 
 [tool.ruff.lint]
-# Add the `line-too-long` rule to the enforced rule set.
-extend-select = ["E501"]
 select = ["ALL"]
 
 ignore = [

--- a/screenshot_mailinator_email.py
+++ b/screenshot_mailinator_email.py
@@ -16,9 +16,13 @@ def screenshot_mailinator_email() -> None:
         )
         page.wait_for_timeout(2000)
         print("Loading email pane")
-        page.evaluate("document.getElementById('email_pane').setAttribute('style', 'height: 500%; width: 100%;');")
+        page.evaluate(
+            "document.getElementById('email_pane').setAttribute('style', 'height: 500%; width: 100%;');"  # noqa: E501
+        )
         print("Enlarging email pane")
-        datetime_string = datetime.now(tz=ZoneInfo("Europe/London")).strftime("%Y-%m-%d_%H-%M-%S")
+        datetime_string = datetime.now(tz=ZoneInfo("Europe/London")).strftime(
+            "%Y-%m-%d_%H-%M-%S"
+        )
         file_name = f"{datetime_string}_email.png"
         page.locator("#email_pane").screenshot(path=file_name)
         print(f"Saved screenshot to {file_name}")

--- a/tests/test_screenshot_mailinator_email.py
+++ b/tests/test_screenshot_mailinator_email.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
-from screenshot_mailinator_email.screenshot_mailinator_email import screenshot_mailinator_email
+from screenshot_mailinator_email.screenshot_mailinator_email import (
+    screenshot_mailinator_email,
+)
 
 
 @patch("sys.argv", ["https://mailinator.com"])


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to improve code readability and maintainability. The changes focus on reformatting code to adhere to style guidelines and updating import statements for clarity.

Code readability improvements:

* [`screenshot_mailinator_email.py`](diffhunk://#diff-eb5f21e988b3979b16f64027f13224a42f24b0e13ef1789ea820bb4a7b0bc2d4L19-R25): Reformatted long lines to comply with style guidelines by breaking them into multiple lines and adding `# noqa: E501` comments where necessary.

* [`tests/test_screenshot_mailinator_email.py`](diffhunk://#diff-d4c8e19ae5861660ed269348178b92b83731bbf4e41f439e56656b49db98c525L3-R5): Updated import statements to use a multi-line format for better readability.

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L20-L25): Removed the `line-length` setting and the comment and rule related to `line-too-long` from the `[tool.ruff.lint]` section, simplifying the configuration.
