### PR TITLE
Set markdown-link-checker job runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -97,7 +97,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change updates the `runs-on` parameter for the `check-markdown-links` job to use the latest Ubuntu version.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L100-R100): Updated `runs-on` parameter from `ubuntu-latest` to `ubuntu-22.04` for the `check-markdown-links` job.