### PR TITLE
Add CodeQL GitHub Actions Scanning

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -127,24 +127,7 @@ jobs:
       - name: Check Justfile Format
         run: just format-check
 
-  run-codeql-analysis:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.0
-        with:
-          languages: javascript
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.0
+  run-codsuses: github/codeql-action/analyze@v3.28.1
 
   run-code-limit:
     name: Run CodeLimit

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -59,7 +59,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.0
+        uses: github/codeql-action/upload-sarif@v3.28.1
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -127,7 +127,28 @@ jobs:
       - name: Check Justfile Format
         run: just format-check
 
-  run-codsuses: github/codeql-action/analyze@v3.28.1
+  run-codeql-analysis:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    strategy:
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3.28.1
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3.28.1
 
   run-code-limit:
     name: Run CodeLimit
@@ -162,7 +183,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.0
+        uses: github/codeql-action/upload-sarif@v3.28.1
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/workflows/code-checks.yml` file, specifically removing the CodeQL analysis job and updating the version of the `codeql-action/analyze` used.

Changes to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L130-R130): Removed the `run-codeql-analysis` job, which included checking out the repository, initializing CodeQL, and performing CodeQL analysis.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L130-R130): Updated the `codeql-action/analyze` action to version `v3.28.1`.
