### PR TITLE
Switch Dependabot Configuration from pip to uv

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@v5.3.0
+      uses: astral-sh/setup-uv@v5.4.1
       with:
         pyproject-file: "pyproject.toml"
         enable-cache: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "patch"
           - "minor"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -146,13 +146,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.10
+        uses: github/codeql-action/init@v3.28.15
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.10
+        uses: github/codeql-action/analyze@v3.28.15
 
   run-code-limit:
     name: Run CodeLimit
@@ -187,7 +187,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.15
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to various GitHub Actions and Dependabot configuration files. The main changes involve updating the versions of actions being used and modifying the package ecosystem for dependency updates.

Updates to GitHub Actions:

* [`.github/actions/setup-python-dependencies/action.yml`](diffhunk://#diff-4cb40b2fa462f005bed001da7016592925ba7d2dfa1011ffdeedf6a8b0f7fedbL8-R8): Updated `astral-sh/setup-uv` action from version `v5.3.0` to `v5.4.1`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L149-R155): Updated `github/codeql-action/init`, `github/codeql-action/analyze`, and `github/codeql-action/upload-sarif` actions from version `v3.28.10` to `v3.28.15`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L149-R155) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L190-R190)

Updates to Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L21-R21): Changed the package ecosystem from `pip` to `uv` for dependency updates.