### PR TITLE
Migrate Git Hooks to Lefthook

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -78,6 +78,7 @@ ruff-format-fix:
 # Check for unused code
 vulture:
     uv run vulture screenshot_mailinator_email.py
+
 # ------------------------------------------------------------------------------
 # Prettier
 # ------------------------------------------------------------------------------

--- a/Justfile
+++ b/Justfile
@@ -78,16 +78,15 @@ ruff-format-fix:
 # Check for unused code
 vulture:
     uv run vulture screenshot_mailinator_email.py
-
 # ------------------------------------------------------------------------------
-# Prettier - File Formatting
+# Prettier
 # ------------------------------------------------------------------------------
 
-# Check for prettier issues
+# Check all files with prettier
 prettier-check:
     prettier . --check
 
-# Fix prettier issues
+# Format all files with prettier
 prettier-format:
     prettier . --check --write
 
@@ -95,20 +94,37 @@ prettier-format:
 # Justfile
 # ------------------------------------------------------------------------------
 
-# Format the Just code
+# Format Justfile
 format:
     just --fmt --unstable
 
-# Check for Just format issues
+# Check Justfile formatting
 format-check:
     just --fmt --check --unstable
 
 # ------------------------------------------------------------------------------
-# gitleaks
+# Gitleaks
 # ------------------------------------------------------------------------------
 
+# Run gitleaks detection
 gitleaks-detect:
-    gitleaks detect --source . > /dev/null
+    gitleaks detect --source .
+
+# ------------------------------------------------------------------------------
+# Lefthook
+# ------------------------------------------------------------------------------
+
+# Validate lefthook config
+lefthook-validate:
+    lefthook validate
+
+# ------------------------------------------------------------------------------
+# Zizmor
+# ------------------------------------------------------------------------------
+
+# Run zizmor checking
+zizmor-check:
+    zizmor .
 
 # ------------------------------------------------------------------------------
 # Git Hooks
@@ -116,6 +132,4 @@ gitleaks-detect:
 
 # Install pre commit hook to run on all commits
 install-git-hooks:
-    cp -f githooks/pre-commit .git/hooks/pre-commit
-    cp -f githooks/post-commit .git/hooks/post-commit
-    chmod ug+x .git/hooks/*
+    lefthook install -f

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,20 @@
+# https://github.com/evilmartians/lefthook
+min_version: 1.11.8
+colors: true
+
+output:
+  - summary
+
+pre-commit:
+  parallel: true
+  commands:
+    Git Leaks Detection:
+      run: just gitleaks-detect
+    Prettier Checks:
+      run: just prettier-check
+    Justfile Format Checks:
+      run: just format-check
+    Lefthook Validate:
+      run: just lefthook-validate
+    Zizmor Checks:
+      run: just zizmor-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces several updates to the `Justfile` and adds a new `lefthook.yml` configuration file to streamline code formatting and validation processes. The most important changes include renaming and reformatting commands in the `Justfile`, adding new commands for `lefthook` and `zizmor`, and setting up `lefthook` to manage pre-commit hooks.

Updates to `Justfile`:

* Renamed and reformatted various commands for clarity, such as changing `prettier-check` and `prettier-format` descriptions to better reflect their functionality.
* Added new commands for `lefthook` validation and `zizmor` checking.
* Updated the `install-git-hooks` command to use `lefthook install -f` instead of manually copying and setting permissions for git hooks.

New `lefthook.yml` configuration:

* Added `lefthook.yml` to configure `lefthook` with a minimum version, color output, and summary output.
* Defined pre-commit hooks to run various checks in parallel, including Git Leaks Detection, Prettier Checks, Justfile Format Checks, Lefthook Validate, and Zizmor Checks.