### PR TITLE
Validate Lefthook Configuration

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -130,6 +130,22 @@ jobs:
       - name: Check Justfile Format
         run: just format-check
 
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.4.1
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate
+
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow to validate Lefthook configurations. The most important change is the addition of the `lefthook-validate` job, which ensures that Lefthook configurations are properly validated during the CI process.

New job addition:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R133-R148): Added a new `lefthook-validate` job to validate Lefthook configurations using the `uvx lefthook validate` command. This job includes steps to checkout the repository, install the latest version of `uv`, and run the Lefthook validation.
