### PR TITLE
Bump Lefthook Version

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.8
+min_version: 1.11.10
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `lefthook.yml` file. The change updates the minimum version requirement for Lefthook from 1.11.8 to 1.11.10.
