### PR TITLE
Add Pinact Verify Job

### DIFF
--- a/.github/actions/setup-python-dependencies/action.yml
+++ b/.github/actions/setup-python-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
         pyproject-file: "pyproject.toml"
         enable-cache: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run Unit Tests
         run: just unit-test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@c6d4525e9f50b27a0e78fc42b537141058d034ef # v1.3.1
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -138,7 +138,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -204,3 +204,17 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
+
+  pinact-verify:
+    name: Pinact Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions dependencies to their latest versions and introduces a new workflow job for verifying "Pinact." The changes improve the maintainability and functionality of the CI/CD pipeline.

### Dependency Updates:
* Updated `astral-sh/setup-uv` from `v5.4.1` to `v5.4.2` in both `.github/actions/setup-python-dependencies/action.yml` and `.github/workflows/code-checks.yml`. This ensures the latest version of UV is used for Python setup and other tasks. [[1]](diffhunk://#diff-4cb40b2fa462f005bed001da7016592925ba7d2dfa1011ffdeedf6a8b0f7fedbL8-R8) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L141-R141)
* Updated `SonarSource/sonarqube-scan-action` from `v5.0.0` to `v5.1.0` in `.github/workflows/code-checks.yml` for improved SonarCloud scanning capabilities.
* Updated `UmbrellaDocs/action-linkspector` from `v1.3.1` to `v1.3.4` in `.github/workflows/code-checks.yml` to enhance Markdown link checking.

### New Workflow Job:
* Added a new `pinact-verify` job to `.github/workflows/code-checks.yml`. This job checks out the repository and installs the latest version of UV for verification purposes.