### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       - ".github/actions/setup-python-dependencies"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -21,7 +21,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       python:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,8 @@ updates:
       - "/"
       - ".github/actions/setup-python-dependencies"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -21,9 +20,8 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to switch from a daily schedule to a cron-based schedule for dependency updates. The new schedule specifies updates to run at 7:30 AM UTC daily.

**Changes to Dependabot configuration:**

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R10): Replaced the `interval` and `time` fields with a `cronjob` field for both the root directory and the Python dependencies directory, specifying a cron schedule of `30 7 * * *` [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R10) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L24-R24).