### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,15 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -22,9 +26,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to enhance the scheduling and grouping of dependency updates. The changes include adding a timezone specification and refining the grouping rules for version updates.

**Enhancements to scheduling:**
* Added a `timezone` field to the schedule configuration, specifying "Europe/London" for cron jobs.

**Refinements to dependency grouping:**
* Introduced the `applies-to` field for the `github-actions` group, targeting "version-updates" specifically.
* Added an `exclude-patterns` field to the `github-actions` group, excluding updates matching "super-linter/*".
* Similarly, added the `applies-to` field for the `python` group, targeting "version-updates".