### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -60,7 +60,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: ruff-results.sarif
       - name: Check Python Code Format (Ruff)
@@ -97,9 +97,10 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
+      actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -111,7 +112,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates multiple GitHub Actions workflows to use newer versions of reusable workflows and actions. Additionally, it includes a minor permissions change for the `code-checks` workflow.

### Workflow updates:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated reusable workflow version from `v2025.05.24.02` to `v2025.06.06.01`.
* `.github/workflows/code-checks.yml`: 
  - Updated reusable workflow versions for `common-code-checks.yml` and `codeql-analysis.yml` to `v2025.06.06.01`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R100-R103) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L114-R115)
  - Updated `github/codeql-action/upload-sarif` action version from `v3.28.18` to `v3.28.19`.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15): Updated reusable workflow version from `v2025.05.24.02` to `v2025.06.06.01`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated reusable workflow version from `v2025.05.24.02` to `v2025.06.06.01`.

### Permissions change:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R100-R103): Added `actions: read` permission to the workflow.
