### PR TITLE
Remove CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -178,18 +178,3 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     with:
       language: ${{ matrix.language }}
-
-  run-code-limit:
-    name: Run CodeLimit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: "Run Code Limit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `run-code-limit` job from the `.github/workflows/code-checks.yml` file. The job previously ran the CodeLimit action to check code limits during workflow execution.

Key change:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L181-L195): Removed the `run-code-limit` job, including its configuration and steps, such as repository checkout and execution of the CodeLimit action.