### PR TITLE
Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   common-pull-request-tasks:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the GitHub Actions workflow configuration by updating the permissions for the `pull-request-tasks.yml` workflow. The permissions are now set to an empty object, which means the workflow will use the default permissions.

- [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL7-R7): Changed the `permissions` field from specifying `pull-requests: read` to an empty object, reverting to default permissions.